### PR TITLE
Rename methods for improved clarity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     pbapply,
     rmarkdown,
     spelling,
-    testthat,
+    testthat (>= 3.0.0),
     tibble,
     tidyselect,
     vdiffr,
@@ -61,3 +61,4 @@ Language: en-US
 LazyData: TRUE
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
+Config/testthat/edition: 3

--- a/R/compute_coi.R
+++ b/R/compute_coi.R
@@ -56,7 +56,7 @@ compute_coi <- function(data,
                         bin_size = 20,
                         comparison = "overall",
                         distance = "squared",
-                        coi_method = "1") {
+                        coi_method = "variant") {
   ## Check inputs
   assert_in(data_type, c("sim", "real"))
   assert_single_string(data_type)
@@ -68,7 +68,7 @@ compute_coi <- function(data,
   assert_single_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Warnings
   if (comparison != "overall") {
@@ -113,7 +113,7 @@ compute_coi <- function(data,
   # If there is no heterozygous data, it means that the COI = 1. Otherwise, we
   # can compare the expected number of loci and the number of loci our
   # simulation gives us.
-  if (coi_method == "2") {
+  if (coi_method == "frequency") {
     # No heterozygous data present
     if (dim(processed_data)[1] == 0) {
       ret <- list(coi = 1, probability = c(1, rep(0, max_coi - 1)))

--- a/R/optimize.R
+++ b/R/optimize.R
@@ -22,28 +22,26 @@
 likelihood <- function(coi,
                        processed_data,
                        distance = "squared",
-                       coi_method = "1") {
+                       coi_method = "variant") {
   # Check inputs
   assert_single_pos(coi)
-  assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
   assert_single_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Compute theoretical curve
-  if (coi_method == "1") {
+  if (coi_method == "variant") {
     theory_coi <- theoretical_coi(
       coi,
       processed_data$midpoints,
-      coi_method = "1"
+      coi_method = "variant"
     )
   } else {
     theory_coi <- theoretical_coi(
       coi,
       processed_data$midpoints,
-      coi_method = "2"
+      coi_method = "frequency"
     )
   }
 
@@ -89,7 +87,7 @@ optimize_coi <- function(data,
                          seq_error = NULL,
                          bin_size = 20,
                          distance = "squared",
-                         coi_method = "1") {
+                         coi_method = "variant") {
 
   # Check inputs
   assert_in(data_type, c("sim", "real"))
@@ -100,7 +98,7 @@ optimize_coi <- function(data,
   assert_single_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Warnings
   if (distance != "squared") {

--- a/R/process.R
+++ b/R/process.R
@@ -26,7 +26,7 @@ process <- function(wsaf,
                     plaf,
                     seq_error = NULL,
                     bin_size = 20,
-                    coi_method = "1") {
+                    coi_method = "variant") {
 
   # Infer value of seq_error if NULL
   if (is.null(seq_error)) {
@@ -59,14 +59,14 @@ process <- function(wsaf,
     seq_error <- round(max(seq_error, 0.01, na.rm = T), 4)
   }
 
-  if (coi_method == "1") {
+  if (coi_method == "variant") {
     # Isolate PLAF, determine the PLAF cuts, and whether a site is a variant,
     # accounting for sequence error
     df <- data.frame(
       plaf_cut = suppressWarnings(Hmisc::cut2(plaf, m = bin_size)),
       variant = ifelse(wsaf <= seq_error | wsaf >= (1 - seq_error), 0, 1)
     )
-  } else if (coi_method == "2") {
+  } else if (coi_method == "frequency") {
     # Subset to heterozygous sites
     data <- data.frame(wsaf = wsaf, plaf = plaf) %>%
       dplyr::filter(wsaf > seq_error & wsaf < (1 - seq_error))
@@ -185,7 +185,7 @@ process <- function(wsaf,
 process_sim <- function(sim,
                         seq_error = NULL,
                         bin_size = 20,
-                        coi_method = "1") {
+                        coi_method = "variant") {
   # Check inputs
   if (!is.null(seq_error)) assert_single_bounded(seq_error)
   assert_single_pos_int(bin_size)
@@ -231,7 +231,7 @@ process_sim <- function(sim,
 process_real <- function(wsaf, plaf,
                          seq_error = NULL,
                          bin_size = 20,
-                         coi_method = "1") {
+                         coi_method = "variant") {
   # Check inputs
   assert_vector(wsaf)
   assert_bounded(wsaf)

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -22,7 +22,7 @@ single_sensitivity <- function(coi = 3,
                                bin_size = 20,
                                comparison = "overall",
                                distance = "squared",
-                               coi_method = "1") {
+                               coi_method = "variant") {
 
   # Check inputs
   assert_single_pos_int(coi)
@@ -41,7 +41,7 @@ single_sensitivity <- function(coi = 3,
   assert_single_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Simulate data
   sim_data <- sim_biallelic(
@@ -114,7 +114,7 @@ sensitivity <- function(repetitions = 10,
                         bin_size = 20,
                         comparison = "overall",
                         distance = "squared",
-                        coi_method = "1") {
+                        coi_method = "variant") {
 
   # Check inputs
   assert_pos_int(repetitions)
@@ -134,7 +134,7 @@ sensitivity <- function(repetitions = 10,
   assert_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Workaround for when seq_error = NULL. Have seq_error saved as NA so
   # our general sensitivity function can deal with it.
@@ -360,7 +360,7 @@ cont_sensitivity <- function(repetitions = 10,
                              bin_size = 20,
                              comparison = "overall",
                              distance = "squared",
-                             coi_method = "1") {
+                             coi_method = "variant") {
 
   # Check inputs
   assert_pos_int(repetitions)
@@ -380,7 +380,7 @@ cont_sensitivity <- function(repetitions = 10,
   assert_string(distance)
   assert_in(distance, c("abs_sum", "sum_abs", "squared"))
   assert_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Create parameter grid
   param_grid <- expand.grid(

--- a/R/theoretical_coi.R
+++ b/R/theoretical_coi.R
@@ -12,7 +12,8 @@
 #' @param coi_range The COIs for which the curve will be calculated.
 #' @param plaf The PLAF over which the curve will be calculated.
 #' @param coi_method The method we will use to calculate the theoretical COI.
-#' The method is either "1" or "2". The default value is "1".
+#'   The method is either "variant" or "frequency". The default value is
+#'   "variant".
 #'
 #' @return The theoretical COI curves for the specified COIs and PLAF.
 #'
@@ -20,14 +21,14 @@
 
 theoretical_coi <- function(coi_range,
                             plaf = seq(0, 0.5, l = 101),
-                            coi_method = "1") {
+                            coi_method = "variant") {
   # Check inputs
   assert_pos(coi_range, zero_allowed = FALSE)
   assert_vector(plaf)
   assert_bounded(plaf, left = 0, right = 0.5)
   assert_increasing(plaf)
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Compute curve for the COIs
   for (i in coi_range) {
@@ -63,19 +64,19 @@ theoretical_coi <- function(coi_range,
 
 single_theoretical_coi <- function(coi,
                                    plaf = seq(0, 0.5, l = 101),
-                                   coi_method = "1") {
+                                   coi_method = "variant") {
   # Check inputs
   assert_single_pos(coi)
   assert_vector(plaf)
   assert_bounded(plaf, left = 0, right = 0.5)
   assert_increasing(plaf)
   assert_single_string(coi_method)
-  assert_in(coi_method, c("1", "2"))
+  assert_in(coi_method, c("variant", "frequency"))
 
   # Determine the curve
-  if (coi_method == "1") {
+  if (coi_method == "variant") {
     curve <- 1 - plaf^coi - (1 - plaf)^coi
-  } else if (coi_method == "2") {
+  } else if (coi_method == "frequency") {
     curve <- (plaf - plaf^coi) / (1 - plaf^coi - (1 - plaf)^coi)
   }
 }

--- a/analysis/figures.Rmd
+++ b/analysis/figures.Rmd
@@ -63,7 +63,7 @@ het <- ggplot() +
 
 ```{r figures with theoretical and true lines}
 # Method 1 with red lines
-df_grouped_1 <- process_sim(sim, coi_method = "1", bin_size = 50)
+df_grouped_1 <- process_sim(sim, coi_method = "variant", bin_size = 50)
 
 m1r <- ggplot() +
   geom_point(data = m1_data, aes(x = plaf, y = wsaf), alpha = 0.5) +
@@ -92,7 +92,7 @@ m1r <- ggplot() +
   labs(x = "PLMAF", y = "Variant Site", title = "Variant Method")
 
 # Method 2 with red lines
-df_grouped_2 <- process_sim(sim, coi_method = "2", bin_size = 50)
+df_grouped_2 <- process_sim(sim, coi_method = "frequency", bin_size = 50)
 
 m2r <- ggplot() +
   geom_point(data = m2_data, aes(x = plaf, y = wsaf), alpha = 0.5) +

--- a/analysis/real_mccoil_data.Rmd
+++ b/analysis/real_mccoil_data.Rmd
@@ -89,7 +89,7 @@ raw_predictions <- pbapply::pblapply(seq_len(length(rmcl_wsafs)), function(x) {
     ## Compute COI
     # Discrete
     rob_d1 <- function(input) {
-      tryCatch(discrete_1 <- compute_coi(input, "real", coi_method = "1", bin_size = 50)$coi,
+      tryCatch(discrete_1 <- compute_coi(input, "real", coi_method = "variant", bin_size = 50)$coi,
         error = function(e) {
           print(paste("Error for sample", rownames(sample)[i]))
           NaN
@@ -98,7 +98,7 @@ raw_predictions <- pbapply::pblapply(seq_len(length(rmcl_wsafs)), function(x) {
     }
     discrete_1 <- rob_d1(input)
     rob_d2 <- function(input) {
-      tryCatch(discrete_2 <- compute_coi(input, "real", coi_method = "2", bin_size = 50)$coi,
+      tryCatch(discrete_2 <- compute_coi(input, "real", coi_method = "frequency", bin_size = 50)$coi,
         error = function(e) {
           print(paste("Error for sample", rownames(sample)[i]))
           NaN
@@ -109,7 +109,7 @@ raw_predictions <- pbapply::pblapply(seq_len(length(rmcl_wsafs)), function(x) {
 
     # Continuous
     rob_c1 <- function(input) {
-      tryCatch(continuous_1 <- optimize_coi(input, "real", coi_method = "1", bin_size = 50),
+      tryCatch(continuous_1 <- optimize_coi(input, "real", coi_method = "variant", bin_size = 50),
         error = function(e) {
           print(paste("Error for sample", rownames(sample)[i]))
           NaN
@@ -118,7 +118,7 @@ raw_predictions <- pbapply::pblapply(seq_len(length(rmcl_wsafs)), function(x) {
     }
     continuous_1 <- rob_c1(input)
     rob_c2 <- function(input) {
-      tryCatch(continuous_2 <- optimize_coi(input, "real", coi_method = "2", bin_size = 50),
+      tryCatch(continuous_2 <- optimize_coi(input, "real", coi_method = "frequency", bin_size = 50),
         error = function(e) {
           print(paste("Error for sample", rownames(sample)[i]))
           NaN
@@ -126,8 +126,8 @@ raw_predictions <- pbapply::pblapply(seq_len(length(rmcl_wsafs)), function(x) {
       )
     }
     continuous_2 <- rob_c2(input)
-    # continuous_1 <- optimize_coi(input, "real", coi_method = "1")
-    # continuous_2 <- optimize_coi(input, "real", coi_method = "2")
+    # continuous_1 <- optimize_coi(input, "real", coi_method = "variant")
+    # continuous_2 <- optimize_coi(input, "real", coi_method = "frequency")
 
     # coi_region <- discrete_1
     coi_region <- list(
@@ -248,7 +248,7 @@ pivot_data <- compare_data %>%
 
 ```{r figure 3}
 panela <- ggplot(
-  dplyr::filter(pivot_data, coi_method == "1"),
+  dplyr::filter(pivot_data, coi_method == "variant"),
   aes(y = COI, x = rmcl_med, color = optimization)
 ) +
   scale_size_area() +
@@ -265,7 +265,7 @@ panela <- ggplot(
   scale_x_continuous("THE REAL McCOIL Prediction", breaks = seq(0, 10))
 
 panelb <- ggplot(
-  dplyr::filter(pivot_data, coi_method == "2"),
+  dplyr::filter(pivot_data, coi_method == "frequency"),
   aes(y = COI, x = rmcl_med, color = optimization)
 ) +
   scale_size_area() +
@@ -584,7 +584,7 @@ fig4c <- patient_lat_long %>%
   dplyr::relocate(tidyselect::any_of(c("coi_method", "optimization", "COI")),
     .after = name
   ) %>%
-  dplyr::filter(coi_method == "1" & optimization == "discrete")
+  dplyr::filter(coi_method == "variant" & optimization == "discrete")
 
 tt <- fig4c %>%
   dplyr::group_by(Region) %>%

--- a/analysis/relatedness_example.R
+++ b/analysis/relatedness_example.R
@@ -9,36 +9,36 @@ coverage <- 100
 reps <- 20
 
 cois <- 2:10
-rels <- seq(0,0.9, 0.1)
+rels <- seq(0, 0.9, 0.1)
 pars <- expand.grid(k = cois, r = rels)
 results <- vector("list", nrow(pars))
 
-for(i in seq_len(nrow(pars))) {
-
+for (i in seq_len(nrow(pars))) {
   message(i)
   k <- pars$k[i]
   r <- pars$r[i]
 
   dat <- lapply(seq_len(reps), sim_biallelic, coi = k, plaf = p, coverage = coverage, relatedness = r)
 
-  disc_k <- lapply(dat, compute_coi, data_type = "sim", coi_method = "1")
+  disc_k <- lapply(dat, compute_coi, data_type = "sim", coi_method = "variant")
   disc_k <- unlist(lapply(disc_k, "[[", "coi"))
 
-  disc_k_2 <- lapply(dat, compute_coi, data_type = "sim", coi_method = "2")
+  disc_k_2 <- lapply(dat, compute_coi, data_type = "sim", coi_method = "frequency")
   disc_k_2 <- unlist(lapply(disc_k_2, "[[", "coi"))
 
-  cont_k <- lapply(dat, optimize_coi, data_type = "sim", coi_method = "1")
-  cont_k_2 <- lapply(dat, optimize_coi, data_type = "sim", coi_method = "2")
+  cont_k <- lapply(dat, optimize_coi, data_type = "sim", coi_method = "variant")
+  cont_k_2 <- lapply(dat, optimize_coi, data_type = "sim", coi_method = "frequency")
 
   r_est <- unlist(cont_k_2) - unlist(cont_k)
 
-  df <- data.frame("coi" = k, "r" = r,
-                   "rep" = seq_len(reps), "r_est" = r_est,
-                   "coi_d" = unlist(disc_k), "coi_d_2" = unlist(disc_k_2),
-                   "coi_c" = unlist(cont_k), "coi_c_2" = unlist(cont_k_2))
+  df <- data.frame(
+    "coi" = k, "r" = r,
+    "rep" = seq_len(reps), "r_est" = r_est,
+    "coi_d" = unlist(disc_k), "coi_d_2" = unlist(disc_k_2),
+    "coi_c" = unlist(cont_k), "coi_c_2" = unlist(cont_k_2)
+  )
 
   results[[i]] <- df
-
 }
 
 # plot
@@ -46,9 +46,12 @@ plot <- do.call(rbind, results) %>%
   dplyr::mutate(coi_lab = paste0("COI = ", coi))
 
 plot$coi_lab <- factor(plot$coi_lab,
-                       levels = c("COI = 2", "COI = 3", "COI = 4", "COI = 5",
-                                  "COI = 6", "COI = 7", "COI = 8", "COI = 9",
-                                  "COI = 10"))
+  levels = c(
+    "COI = 2", "COI = 3", "COI = 4", "COI = 5",
+    "COI = 6", "COI = 7", "COI = 8", "COI = 9",
+    "COI = 10"
+  )
+)
 
 ggplot(aes(x = r, y = r_est), data = plot) +
   geom_point(color = "blue", alpha = 0.7, show.legend = FALSE) +
@@ -57,5 +60,5 @@ ggplot(aes(x = r, y = r_est), data = plot) +
   theme_classic() +
   theme(axis.line = element_line()) +
   facet_wrap(~coi_lab) +
-  ylab("Method 2 Continous - Method 1 Continuous") + xlab("Relatedness")
-
+  ylab("Method 2 Continous - Method 1 Continuous") +
+  xlab("Relatedness")

--- a/analysis/vignettes/example_coi_prediction.Rmd
+++ b/analysis/vignettes/example_coi_prediction.Rmd
@@ -11,14 +11,14 @@ vignette: >
 knitr::opts_chunk$set(
   comment = "#>",
   collapse = TRUE,
-  fig.width = 7, 
+  fig.width = 7,
   fig.height = 7
 )
 
 library(coiaf)
 ```
 
-In this analysis the two COI estimation methods are demonstrated. In these we 
+In this analysis the two COI estimation methods are demonstrated. In these we
 will simulate 1000 loci for an individual. We first initialize the population
 level allele frequency (PLAF) using a beta distribution.
 
@@ -35,14 +35,14 @@ p[p > 0.5] <- 1 - p[p > 0.5]
 
 # Method 1
 
-The first approach in the manuscript document for estimating COI is shown below. 
-This works by using the mean number of variant sites, binned in groups of 
+The first approach in the manuscript document for estimating COI is shown below.
+This works by using the mean number of variant sites, binned in groups of
 increasing PLAF to infer COI.
 
 ```{r method 1}
-# Loop over range of COIs 
-end_coi = list()
-opt_coi = list()
+# Loop over range of COIs
+end_coi <- list()
+opt_coi <- list()
 par(mar = c(4, 4, 4, 4))
 par(mfrow = c(3, 2))
 for (k in 2:7) {
@@ -52,73 +52,81 @@ for (k in 2:7) {
   sim1 <- sim_biallelic(coi = k, plaf = p)
 
   # Plot raw WSAF as gray dots
-  plot(sim1$data$plaf, sim1$data$wsaf, 
-       pch = 20, cex = 0.5, col = "gray", ylim = c(0,1),
-       xlab = "PLAF", ylab = "WSAF", main = paste("COI =", k))
+  plot(sim1$data$plaf, sim1$data$wsaf,
+    pch = 20, cex = 0.5, col = "gray", ylim = c(0, 1),
+    xlab = "PLAF", ylab = "WSAF", main = paste("COI =", k)
+  )
 
   # Overlay analytical expectations for COI of 2:7
-  p_vec <- seq(0, 0.5, l=101)
+  p_vec <- seq(0, 0.5, l = 101)
   theory_cois <- theoretical_coi(seq(1, 7), p_vec)
   for (i in 1:7) {
-    lines(p_vec, theory_cois[[paste("coi_", i, sep = "")]], 
-          col = "red", lwd = 2)
+    lines(p_vec, theory_cois[[paste("coi_", i, sep = "")]],
+      col = "red", lwd = 2
+    )
   }
-  text(x = rep(0.505, 6), y = 1 - 0.5^(1:6), labels = 1:7, 
-       col = "red", cex = 0.6)
+  text(
+    x = rep(0.505, 6), y = 1 - 0.5^(1:6), labels = 1:7,
+    col = "red", cex = 0.6
+  )
 
   # Compute windowed averages over WSAF and overlay in blue
   df_grouped <- process_sim(sim1)
 
-  lines(df_grouped$data$midpoints, df_grouped$data$m_variant, 
-        col = "blue", lwd = 2, type = "o", pch = 20)
-  
+  lines(df_grouped$data$midpoints, df_grouped$data$m_variant,
+    col = "blue", lwd = 2, type = "o", pch = 20
+  )
+
   # Predict the COI and print the results
-  calc_coi = compute_coi(sim1, "sim", max_coi = 50, seq_error = 0.01)
-  end_coi = unlist(c(end_coi, calc_coi$coi))
-  
+  calc_coi <- compute_coi(sim1, "sim", max_coi = 50, seq_error = 0.01)
+  end_coi <- unlist(c(end_coi, calc_coi$coi))
+
   # COI using optimization
-  add = optimize_coi(sim1, "sim", max_coi = 10)
-  opt_coi = unlist(c(opt_coi, add))
+  add <- optimize_coi(sim1, "sim", max_coi = 10)
+  opt_coi <- unlist(c(opt_coi, add))
 }
 ```
 
-In this, the intercept at `PLAF = 0.5` gives us an easy way to estimate COI, 
-with `COI = 1 + log_0.5(1-WSAF)`, or `WSAF = 1 - 0.5^(COI-1)`. However, the 
-differences between each COI at PLAF = 0.5 become geometrically smaller. Larger 
+In this, the intercept at `PLAF = 0.5` gives us an easy way to estimate COI,
+with `COI = 1 + log_0.5(1-WSAF)`, or `WSAF = 1 - 0.5^(COI-1)`. However, the
+differences between each COI at PLAF = 0.5 become geometrically smaller. Larger
 gaps can be found at different COI, with smaller PLAF:
 
 ```{r ideal PLAF}
 par(mar = c(4, 4, 4, 4))
 par(mfrow = c(3, 3))
-p_vec <- seq(0, 0.5, l=101)
+p_vec <- seq(0, 0.5, l = 101)
 y <- list()
 for (k in 1:10) {
   y[[k]] <- theoretical_coi(k, p_vec)[[1]]
 
-  if(k > 1) {
-   new_y <- y[[k]]-y[[k-1]]
-   plot(p_vec, new_y,
-        ylab = glue::glue("Difference between COI {k-1} and {k}"),
-        xlab = "PLAF",
-        main = paste("COI = ", k))
-   abline(v=p_vec[which.max(new_y)], lty = 2)
-   text(x=p_vec[which.max(new_y)] - 0.02, y = 0.0, 
-        labels = p_vec[which.max(new_y)])
+  if (k > 1) {
+    new_y <- y[[k]] - y[[k - 1]]
+    plot(p_vec, new_y,
+      ylab = glue::glue("Difference between COI {k-1} and {k}"),
+      xlab = "PLAF",
+      main = paste("COI = ", k)
+    )
+    abline(v = p_vec[which.max(new_y)], lty = 2)
+    text(
+      x = p_vec[which.max(new_y)] - 0.02, y = 0.0,
+      labels = p_vec[which.max(new_y)]
+    )
   }
 }
 ```
 
 # Method 2
 
-In method 2, we plot WSAF against PLAF for only the sites that are 
-heterogeneous, i.e. not all REF or ALT calls. 
+In method 2, we plot WSAF against PLAF for only the sites that are
+heterogeneous, i.e. not all REF or ALT calls.
 
 ```{r method 2}
 # loop over range of COIs
-disc_coi = list()
-cont_coi = list()
+disc_coi <- list()
+cont_coi <- list()
 par(mar = c(4, 4, 4, 4))
-par(mfrow = c(3,2))
+par(mfrow = c(3, 2))
 for (k in 2:7) {
 
   # simulate data and subset to heterozygous sites only
@@ -126,31 +134,34 @@ for (k in 2:7) {
   sim1 <- sim_biallelic(coi = k, plaf = p)
 
   # plot raw WSAF as grey dots
-  plot(sim1$data$plaf, sim1$data$wsaf, pch = 20, cex = 0.5, col = "gray", 
-       ylim = c(0,1), xlab = "PLAF", ylab = "WSAF", main = paste("COI =", k))
+  plot(sim1$data$plaf, sim1$data$wsaf,
+    pch = 20, cex = 0.5, col = "gray",
+    ylim = c(0, 1), xlab = "PLAF", ylab = "WSAF", main = paste("COI =", k)
+  )
 
   # overlay analytical expectations for COI=2:7
-  p_vec <- seq(0, 0.5, l=101)
-  theory_cois <- theoretical_coi(seq(1, 7), p_vec, coi_method = "2")
+  p_vec <- seq(0, 0.5, l = 101)
+  theory_cois <- theoretical_coi(seq(1, 7), p_vec, coi_method = "frequency")
   for (i in 2:7) {
     lines(p_vec, theory_cois[[paste("coi_", i, sep = "")]], col = 2, lwd = 2)
   }
-  text(x = rep(-0.005, 6), y = 1/2:7, labels = 2:7, col = "red", cex = 0.6)
+  text(x = rep(-0.005, 6), y = 1 / 2:7, labels = 2:7, col = "red", cex = 0.6)
 
   # compute sliding-window averages over WSAF and overlay in blue
-  df_grouped <- process_sim(sim1, coi_method = "2")
+  df_grouped <- process_sim(sim1, coi_method = "frequency")
   print(df_grouped$seq_error)
 
   lines(df_grouped$data$midpoints, df_grouped$data$m_variant,
-        col = "blue", lwd = 2, type = "o", pch = 20)
-  
+    col = "blue", lwd = 2, type = "o", pch = 20
+  )
+
   # Predict the COI and print the results
-  disc = compute_coi(sim1, "sim", max_coi = 10, coi_method = "2")
-  disc_coi = unlist(c(disc_coi, disc$coi))
-  
+  disc <- compute_coi(sim1, "sim", max_coi = 10, coi_method = "frequency")
+  disc_coi <- unlist(c(disc_coi, disc$coi))
+
   # COI using optimization
-  cont = optimize_coi(sim1, "sim", max_coi = 10, coi_method = "2")
-  cont_coi = unlist(c(cont_coi, cont))
+  cont <- optimize_coi(sim1, "sim", max_coi = 10, coi_method = "frequency")
+  cont_coi <- unlist(c(cont_coi, cont))
 }
 ```
 

--- a/analysis/vignettes/example_real_data.Rmd
+++ b/analysis/vignettes/example_real_data.Rmd
@@ -12,7 +12,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  fig.width = 5, 
+  fig.width = 5,
   fig.height = 5
 )
 # Change the way tibble prints so only prints 5 extra columns
@@ -41,7 +41,7 @@ First, we must compute the PLAF by average the WSAF of our samples.
 plaf <- colMeans(example_real_data, na.rm = T)
 ```
 
-In the dataset provided, `example_real_data`, there are 
+In the dataset provided, `example_real_data`, there are
 `r dim(example_real_data)[1]` unique samples with `r dim(example_real_data)[2]`
 loci each. Therefore, to find the COI for each sample, we must generate a for
 loop and iterate over each sample.
@@ -52,24 +52,26 @@ loop and iterate over each sample.
 m1_dis <- lapply(seq_len(nrow(example_real_data)), function(i) {
   # We first isolate the WSAF for that sample and then plug the WSAF and PLAF
   # into our function
-  wsaf  <- example_real_data[i,]
+  wsaf <- example_real_data[i, ]
   input <- tibble::tibble(wsaf = wsaf, plaf = plaf) %>% tidyr::drop_na()
-  res <- compute_coi(input, "real", coi_method = "1")
+  res <- compute_coi(input, "real", coi_method = "variant")
 })
 
 # compute_coi returns both the COI and a measure of confidence in our prediction
 # thus we must isolate each separately
-m1_dis_cois <- lapply(m1_dis, function(x) { x$coi }) %>% unlist()  
+m1_dis_cois <- lapply(m1_dis, function(x) {
+  x$coi
+}) %>% unlist()
 
 # extract the probabilities and assign them names based on what COI was checked
-m1_dis_probs <- lapply(m1_dis, function(x) { 
+m1_dis_probs <- lapply(m1_dis, function(x) {
   probs <- x$probability
   names(probs) <- paste0("COI_", 1:length(probs))
   return(probs)
 })
 
 # Assign the name of the sample to the returned vectors
-names(m1_dis_cois)  <- rownames(example_real_data)
+names(m1_dis_cois) <- rownames(example_real_data)
 names(m1_dis_probs) <- rownames(example_real_data)
 ```
 
@@ -78,9 +80,9 @@ names(m1_dis_probs) <- rownames(example_real_data)
 m1_dis_cont <- lapply(seq_len(nrow(example_real_data)), function(i) {
   # We first isolate the WSAF for that sample and then plug the WSAF and PLAF
   # into our function
-  wsaf  <- example_real_data[i,]
+  wsaf <- example_real_data[i, ]
   input <- tibble::tibble(wsaf = wsaf, plaf = plaf) %>% tidyr::drop_na()
-  res <- optimize_coi(input, "real", coi_method = "1")
+  res <- optimize_coi(input, "real", coi_method = "variant")
 }) %>% unlist()
 
 # Assign the name of the sample to the returned vector
@@ -93,24 +95,26 @@ names(m1_dis_cont) <- rownames(example_real_data)
 m2_dis <- lapply(seq_len(nrow(example_real_data)), function(i) {
   # We first isolate the WSAF for that sample and then plug the WSAF and PLAF
   # into our function
-  wsaf  <- example_real_data[i,]
+  wsaf <- example_real_data[i, ]
   input <- tibble::tibble(wsaf = wsaf, plaf = plaf) %>% tidyr::drop_na()
-  res <- compute_coi(input, "real", coi_method = "2")
+  res <- compute_coi(input, "real", coi_method = "frequency")
 })
 
 # compute_coi returns both the COI and a measure of confidence in our prediction
 # thus we must isolate each separately
-m2_dis_cois <- lapply(m2_dis, function(x) { x$coi }) %>% unlist()  
+m2_dis_cois <- lapply(m2_dis, function(x) {
+  x$coi
+}) %>% unlist()
 
 # extract the probabilities and assign them names based on what COI was checked
-m2_dis_probs <- lapply(m2_dis, function(x) { 
+m2_dis_probs <- lapply(m2_dis, function(x) {
   probs <- x$probability
   names(probs) <- paste0("COI_", 1:length(probs))
   return(probs)
 })
 
 # Assign the name of the sample to the returned vectors
-names(m2_dis_cois)  <- rownames(example_real_data)
+names(m2_dis_cois) <- rownames(example_real_data)
 names(m2_dis_probs) <- rownames(example_real_data)
 ```
 
@@ -119,9 +123,9 @@ names(m2_dis_probs) <- rownames(example_real_data)
 m2_dis_cont <- lapply(seq_len(nrow(example_real_data)), function(i) {
   # We first isolate the WSAF for that sample and then plug the WSAF and PLAF
   # into our function
-  wsaf  <- example_real_data[i,]
+  wsaf <- example_real_data[i, ]
   input <- tibble::tibble(wsaf = wsaf, plaf = plaf) %>% tidyr::drop_na()
-  res <- optimize_coi(input, "real", coi_method = "2")
+  res <- optimize_coi(input, "real", coi_method = "frequency")
 }) %>% unlist()
 
 # Assign the name of the sample to the returned vector
@@ -132,17 +136,17 @@ names(m2_dis_cont) <- rownames(example_real_data)
 For roughly 1000 loci and 10 samples, the model will take less than 0.5 seconds
 to run. It may be helpful to include a progress bar when running additional loci
 or samples by replacing `lapply` in the above function with a user defined
-function. We recommend the use of the 
-[`pbapply` package](https://peter.solymos.org/pbapply/), which can be used as 
+function. We recommend the use of the
+[`pbapply` package](https://peter.solymos.org/pbapply/), which can be used as
 follows:
 
 ```{r progress bar function, eval = F}
 # Function to determine if pbapply is installed. If it is installed, it will
 # display a progress bar
-list_apply <- function(x, fun, ...){
+list_apply <- function(x, fun, ...) {
   if (requireNamespace("pbapply", quietly = TRUE)) {
     pbapply::pblapply(x, fun, ...)
-    } else {
+  } else {
     lapply(x, fun, ...)
   }
 }
@@ -153,6 +157,6 @@ All that is left to do is to replace the above `lapply` with the newly defined
 
 # Data Visualization
 We recommend exploring the [`ggplot2`](https://ggplot2.tidyverse.org/index.html)
-package to plot results. The 
-[Graph Gallery](https://www.r-graph-gallery.com/index.html) is a beautiful 
+package to plot results. The
+[Graph Gallery](https://www.r-graph-gallery.com/index.html) is a beautiful
 website with tons of awesome graphs and demos that may provide some inspiration.

--- a/analysis/vignettes/sensitivity_analysis_continuous.Rmd
+++ b/analysis/vignettes/sensitivity_analysis_continuous.Rmd
@@ -98,7 +98,7 @@ toverall <- cont_sensitivity(
   plaf = p,
   coverage = 400,
   seq_error = 0,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 toverall_image <- sensitivity_plot(
@@ -106,7 +106,7 @@ toverall_image <- sensitivity_plot(
   dims = c(1, 2),
   result_type = "cont",
   title = "Predicted COI",
-  sub_title = c("Method 1", "Method 2")
+  sub_title = c("Variant Method", "Frequency Method")
 )
 
 toverall_error <- error_plot(
@@ -114,7 +114,7 @@ toverall_error <- error_plot(
   fill = "coi_method",
   legend_title = "COI Method",
   title = "Error",
-  fill_levels = c("Method 1", "Method 2")
+  fill_levels = c("Variant Method", "Frequency Method")
 )
 
 toverall_fig <- ggpubr::ggarrange(
@@ -141,7 +141,7 @@ tcoi <- cont_sensitivity(
   repetitions = 100,
   plaf = p,
   seq_error = 0.01,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tcoi_image <- sensitivity_plot(
@@ -149,7 +149,7 @@ tcoi_image <- sensitivity_plot(
   dims = c(1, 2),
   result_type = "cont",
   title = "Predicted COI",
-  sub_title = c("Method 1", "Method 2")
+  sub_title = c("Variant Method", "Frequency Method")
 )
 
 tcoi_error <- error_plot(
@@ -157,7 +157,7 @@ tcoi_error <- error_plot(
   fill = "coi_method",
   legend_title = "COI Method",
   title = "Error",
-  fill_levels = c("Method 1", "Method 2")
+  fill_levels = c("Variant Method", "Frequency Method")
 )
 
 tcoi_fig <- ggpubr::ggarrange(
@@ -224,7 +224,7 @@ tdistance <- cont_sensitivity(
   distance = c("abs_sum", "sum_abs", "squared"),
   repetitions = 100,
   seq_error = 0.01,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tdistance_image <- sensitivity_plot(
@@ -234,7 +234,7 @@ tdistance_image <- sensitivity_plot(
   dims = c(3, 2),
   sub_title = paste(
     rep(c("Absolute Sum", "Sum of Absolute", "Squared Error"), 2),
-    rep(c("Method 1", "Method 2"), each = 3),
+    rep(c("Variant Method", "Frequency Method"), each = 3),
     sep = ", "
   )
 )
@@ -271,7 +271,7 @@ tcoverage <- cont_sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tcoverage_image <- sensitivity_plot(
@@ -281,7 +281,7 @@ tcoverage_image <- sensitivity_plot(
   dims = c(4, 3),
   sub_title = paste(
     paste0("Coverage ", c(25, 50, 100, 200, 400, 800)),
-    rep(c("Method 1", "Method 2"), each = 6),
+    rep(c("Variant Method", "Frequency Method"), each = 6),
     sep = ", "
   )
 )
@@ -324,7 +324,7 @@ bloci <- lapply(loci, function(new_L) {
     repetitions = 100,
     plaf = new_p,
     seq_error = 0.01,
-    coi_method = "1"
+    coi_method = "variant"
   )
   inner_tloci$param_grid$loci <- new_L
   return(inner_tloci)
@@ -411,7 +411,7 @@ bloci <- lapply(loci, function(new_L) {
     repetitions = 100,
     plaf = new_p,
     seq_error = 0.01,
-    coi_method = "2"
+    coi_method = "frequency"
   )
   inner_tloci$param_grid$loci <- new_L
   return(inner_tloci)
@@ -572,7 +572,7 @@ tover <- cont_sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tover_image <- sensitivity_plot(
@@ -582,7 +582,7 @@ tover_image <- sensitivity_plot(
   dims = c(4, 3),
   sub_title = paste(
     paste0("Over ", seq(0, 0.2, 0.05)),
-    rep(c("Method 1", "Method 2"), each = 5),
+    rep(c("Variant Method", "Frequency Method"), each = 5),
     sep = ", "
   )
 )
@@ -618,7 +618,7 @@ trelated <- cont_sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 trelated_image <- sensitivity_plot(
@@ -628,7 +628,7 @@ trelated_image <- sensitivity_plot(
   dims = c(4, 3),
   sub_title = paste(
     paste0("Related =  ", seq(0, 0.5, 0.1)),
-    rep(c("Method 1", "Method 2"), each = 6),
+    rep(c("Variant Method", "Frequency Method"), each = 6),
     sep = ", "
   )
 )
@@ -746,7 +746,7 @@ tbin <- cont_sensitivity(
   plaf = p,
   repetitions = 100,
   seq_error = 0.01,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tbin_image <- sensitivity_plot(

--- a/analysis/vignettes/sensitivity_analysis_discrete.Rmd
+++ b/analysis/vignettes/sensitivity_analysis_discrete.Rmd
@@ -97,7 +97,7 @@ toverall <- sensitivity(
   plaf = p,
   coverage = 1000,
   seq_error = 0,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 toverall_image <- sensitivity_plot(
@@ -105,14 +105,14 @@ toverall_image <- sensitivity_plot(
   dims = c(1, 2),
   result_type = "disc",
   title = "Predicted COI",
-  sub_title = c("Method 1", "Method 2")
+  sub_title = c("Variant Method", "Frequency Method")
 )
 
 toverall_error <- error_plot(toverall,
   fill = "coi_method",
   legend_title = "COI Method",
   title = "Error",
-  fill_levels = c("Method 1", "Method 2")
+  fill_levels = c("Variant Method", "Frequency Method")
 )
 
 toverall_fig <- ggpubr::ggarrange(
@@ -139,7 +139,7 @@ tcoi <- sensitivity(
   repetitions = 100,
   plaf = p,
   seq_error = 0.01,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tcoi_image <- sensitivity_plot(
@@ -147,7 +147,7 @@ tcoi_image <- sensitivity_plot(
   dims = c(1, 2),
   result_type = "disc",
   title = "Predicted COI",
-  sub_title = c("Method 1", "Method 2")
+  sub_title = c("Variant Method", "Frequency Method")
 )
 
 tcoi_error <- error_plot(
@@ -155,7 +155,7 @@ tcoi_error <- error_plot(
   fill = "coi_method",
   legend_title = "COI Method",
   title = "Error",
-  fill_levels = c("Method 1", "Method 2")
+  fill_levels = c("Variant Method", "Frequency Method")
 )
 
 tcoi_fig <- ggpubr::ggarrange(
@@ -220,8 +220,8 @@ tdistance <- sensitivity(
   comparison = "overall",
   distance = c("abs_sum", "sum_abs", "squared"),
   repetitions = 100,
-  coi_method = c("1", "2"),
-  seq_error = 0.01
+  seq_error = 0.01,
+  coi_method = c("variant", "frequency")
 )
 
 tdistance_image <- sensitivity_plot(
@@ -231,7 +231,7 @@ tdistance_image <- sensitivity_plot(
   dims = c(3, 2),
   sub_title = paste(
     rep(c("Absolute Sum", "Sum of Absolute", "Squared Error"), 2),
-    rep(c("Method 1", "Method 2"), each = 3),
+    rep(c("Variant Method", "Frequency Method"), each = 3),
     sep = ", "
   )
 )
@@ -267,7 +267,7 @@ tcoverage_1 <- sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = "1"
+  coi_method = "variant"
 )
 
 tcoverage_image_1 <- sensitivity_plot(
@@ -302,7 +302,7 @@ tcoverage_2 <- sensitivity(
   coverage = c(50, 100, 250, 500, 1000, 2000),
   repetitions = 100,
   seq_error = 0.01,
-  plaf = p, coi_method = "2"
+  plaf = p, coi_method = "frequency"
 )
 
 tcoverage_image_2 <- sensitivity_plot(
@@ -351,7 +351,7 @@ bloci <- lapply(loci, function(new_L) {
     repetitions = 100,
     plaf = new_p,
     seq_error = 0.01,
-    coi_method = "1"
+    coi_method = "variant"
   )
   inner_tloci$param_grid$loci <- new_L
   return(inner_tloci)
@@ -439,7 +439,7 @@ bloci <- lapply(loci, function(new_L) {
     repetitions = 100,
     plaf = new_p,
     seq_error = 0.01,
-    coi_method = "2"
+    coi_method = "frequency"
   )
   inner_tloci$param_grid$loci <- new_L
   return(inner_tloci)
@@ -600,7 +600,7 @@ tover <- sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tover_image <- sensitivity_plot(
@@ -610,7 +610,7 @@ tover_image <- sensitivity_plot(
   dims = c(4, 3),
   sub_title = paste(
     paste0("Over ", seq(0, 0.2, 0.05)),
-    rep(c("Method 1", "Method 2"), each = 5),
+    rep(c("Variant Method", "Frequency Method"), each = 5),
     sep = ", "
   )
 )
@@ -646,7 +646,7 @@ trelated <- sensitivity(
   repetitions = 100,
   seq_error = 0.01,
   plaf = p,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 trelated_image <- sensitivity_plot(
@@ -656,7 +656,7 @@ trelated_image <- sensitivity_plot(
   dims = c(4, 3),
   sub_title = paste(
     paste0("Related =  ", seq(0, 0.5, 0.1)),
-    rep(c("Method 1", "Method 2"), each = 6),
+    rep(c("Variant Method", "Frequency Method"), each = 6),
     sep = ", "
   )
 )
@@ -729,7 +729,7 @@ tseq <- sensitivity(
   seq_error = seq(0.1, 0.16, 0.02),
   repetitions = 100,
   plaf = p,
-  coi_method = "2"
+  coi_method = "frequency"
 )
 
 # ep_title <- rep(paste0("Epsilon=", seq(0, 0.010, 0.005), 2))
@@ -774,7 +774,7 @@ tbin <- sensitivity(
   plaf = p,
   repetitions = 100,
   seq_error = 0.01,
-  coi_method = c("1", "2")
+  coi_method = c("variant", "frequency")
 )
 
 tbin_image <- sensitivity_plot(

--- a/man/compute_coi.Rd
+++ b/man/compute_coi.Rd
@@ -37,7 +37,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/compute_coi.Rd
+++ b/man/compute_coi.Rd
@@ -12,7 +12,7 @@ compute_coi(
   bin_size = 20,
   comparison = "overall",
   distance = "squared",
-  coi_method = "1"
+  coi_method = "variant"
 )
 }
 \arguments{

--- a/man/cont_sensitivity.Rd
+++ b/man/cont_sensitivity.Rd
@@ -67,7 +67,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/cont_sensitivity.Rd
+++ b/man/cont_sensitivity.Rd
@@ -18,7 +18,7 @@ cont_sensitivity(
   bin_size = 20,
   comparison = "overall",
   distance = "squared",
-  coi_method = "1"
+  coi_method = "variant"
 )
 }
 \arguments{

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -4,7 +4,7 @@
 \alias{likelihood}
 \title{Likelihood of a COI}
 \usage{
-likelihood(coi, processed_data, distance = "squared", coi_method = "1")
+likelihood(coi, processed_data, distance = "squared", coi_method = "variant")
 }
 \arguments{
 \item{coi}{The COI for which the likelihood will be generated.}

--- a/man/likelihood.Rd
+++ b/man/likelihood.Rd
@@ -17,7 +17,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 The likelihood for a specific COI value.

--- a/man/optimize_coi.Rd
+++ b/man/optimize_coi.Rd
@@ -33,7 +33,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 The predicted COI value.

--- a/man/optimize_coi.Rd
+++ b/man/optimize_coi.Rd
@@ -11,7 +11,7 @@ optimize_coi(
   seq_error = NULL,
   bin_size = 20,
   distance = "squared",
-  coi_method = "1"
+  coi_method = "variant"
 )
 }
 \arguments{

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -4,7 +4,7 @@
 \alias{process}
 \title{Process data}
 \usage{
-process(wsaf, plaf, seq_error = NULL, bin_size = 20, coi_method = "1")
+process(wsaf, plaf, seq_error = NULL, bin_size = 20, coi_method = "variant")
 }
 \arguments{
 \item{wsaf}{The within-sample allele frequency.}
@@ -17,7 +17,8 @@ is inputted, then we infer the level of sequence error.}
 \item{bin_size}{The minimum size of each bin of data.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/process_real.Rd
+++ b/man/process_real.Rd
@@ -4,7 +4,13 @@
 \alias{process_real}
 \title{Process real data}
 \usage{
-process_real(wsaf, plaf, seq_error = NULL, bin_size = 20, coi_method = "1")
+process_real(
+  wsaf,
+  plaf,
+  seq_error = NULL,
+  bin_size = 20,
+  coi_method = "variant"
+)
 }
 \arguments{
 \item{wsaf}{The within-sample allele frequency.}
@@ -17,7 +23,8 @@ is inputted, then we infer the level of sequence error.}
 \item{bin_size}{The minimum size of each bin of data.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/process_sim.Rd
+++ b/man/process_sim.Rd
@@ -4,7 +4,7 @@
 \alias{process_sim}
 \title{Process simulated data}
 \usage{
-process_sim(sim, seq_error = NULL, bin_size = 20, coi_method = "1")
+process_sim(sim, seq_error = NULL, bin_size = 20, coi_method = "variant")
 }
 \arguments{
 \item{sim}{Output of \code{\link[=sim_biallelic]{sim_biallelic()}}.}
@@ -15,7 +15,8 @@ is inputted, then we infer the level of sequence error.}
 \item{bin_size}{The minimum size of each bin of data.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/sensitivity.Rd
+++ b/man/sensitivity.Rd
@@ -18,7 +18,7 @@ sensitivity(
   bin_size = 20,
   comparison = "overall",
   distance = "squared",
-  coi_method = "1"
+  coi_method = "variant"
 )
 }
 \arguments{

--- a/man/sensitivity.Rd
+++ b/man/sensitivity.Rd
@@ -67,7 +67,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 A list of the following:

--- a/man/single_sensitivity.Rd
+++ b/man/single_sensitivity.Rd
@@ -17,7 +17,7 @@ single_sensitivity(
   bin_size = 20,
   comparison = "overall",
   distance = "squared",
-  coi_method = "1"
+  coi_method = "variant"
 )
 }
 \arguments{

--- a/man/single_sensitivity.Rd
+++ b/man/single_sensitivity.Rd
@@ -64,7 +64,8 @@ the theoretical and simulated curves for the \code{"overall"} method. One of
 \code{"abs_sum"}, \code{"sum_abs"}, \code{"squared"}.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 Predicted COI value.

--- a/man/single_theoretical_coi.Rd
+++ b/man/single_theoretical_coi.Rd
@@ -4,7 +4,11 @@
 \alias{single_theoretical_coi}
 \title{Single Theoretical COI}
 \usage{
-single_theoretical_coi(coi, plaf = seq(0, 0.5, l = 101), coi_method = "1")
+single_theoretical_coi(
+  coi,
+  plaf = seq(0, 0.5, l = 101),
+  coi_method = "variant"
+)
 }
 \arguments{
 \item{coi}{The COI for which the curve will be calculated.}
@@ -12,7 +16,8 @@ single_theoretical_coi(coi, plaf = seq(0, 0.5, l = 101), coi_method = "1")
 \item{plaf}{The PLAF over which the curve will be calculated.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 The theoretical COI curve for the specified PLAF.

--- a/man/theoretical_coi.Rd
+++ b/man/theoretical_coi.Rd
@@ -4,7 +4,7 @@
 \alias{theoretical_coi}
 \title{Theoretical COI}
 \usage{
-theoretical_coi(coi_range, plaf = seq(0, 0.5, l = 101), coi_method = "1")
+theoretical_coi(coi_range, plaf = seq(0, 0.5, l = 101), coi_method = "variant")
 }
 \arguments{
 \item{coi_range}{The COIs for which the curve will be calculated.}
@@ -12,7 +12,8 @@ theoretical_coi(coi_range, plaf = seq(0, 0.5, l = 101), coi_method = "1")
 \item{plaf}{The PLAF over which the curve will be calculated.}
 
 \item{coi_method}{The method we will use to calculate the theoretical COI.
-The method is either "1" or "2". The default value is "1".}
+The method is either "variant" or "frequency". The default value is
+"variant".}
 }
 \value{
 The theoretical COI curves for the specified COIs and PLAF.

--- a/tests/testthat/test_assertions.R
+++ b/tests/testthat/test_assertions.R
@@ -1,5 +1,3 @@
-context("assertions")
-
 #------------------------------------------------
 test_that("nice_format working correctly", {
   expect_true(nice_format(NULL) == "")
@@ -26,11 +24,11 @@ test_that("assert_non_null working correctly", {
 test_that("assert_atomic correctly", {
   expect_true(assert_atomic(TRUE))
   expect_true(assert_atomic(1))
-  expect_true(assert_atomic(seq(0,5,0.5)))
+  expect_true(assert_atomic(seq(0, 5, 0.5)))
   expect_true(assert_atomic(0i))
   expect_true(assert_atomic("foo"))
   expect_true(assert_atomic(raw(8)))
-  expect_true(assert_atomic(matrix(0,3,3)))
+  expect_true(assert_atomic(matrix(0, 3, 3)))
 
   expect_error(assert_atomic(list(1:5)))
   expect_error(assert_atomic(data.frame(1:5)))
@@ -45,7 +43,7 @@ test_that("assert_single correctly", {
   expect_error(assert_single(NULL))
   expect_error(assert_single(1:5))
   expect_error(assert_single(list(0)))
-  expect_error(assert_single(matrix(0,3,3)))
+  expect_error(assert_single(matrix(0, 3, 3)))
   expect_error(assert_single(data.frame(0)))
 })
 
@@ -121,7 +119,7 @@ test_that("assert_int working correctly", {
   expect_error(assert_int(NULL))
   expect_error(assert_int(0.5))
   expect_error(assert_int("foo"))
-  expect_error(assert_int(c(5,"foo")))
+  expect_error(assert_int(c(5, "foo")))
 })
 
 #------------------------------------------------
@@ -133,7 +131,7 @@ test_that("assert_single_int working correctly", {
   expect_error(assert_single_int(NULL))
   expect_error(assert_single_int(0.5))
   expect_error(assert_single_int("foo"))
-  expect_error(assert_single_int(c(5,"foo")))
+  expect_error(assert_single_int(c(5, "foo")))
 })
 
 #------------------------------------------------
@@ -200,15 +198,15 @@ test_that("assert_vector working correctly", {
   expect_true(assert_vector(1:5))
 
   expect_error(assert_vector(NULL))
-  expect_error(assert_vector(matrix(5,3,3)))
+  expect_error(assert_vector(matrix(5, 3, 3)))
   expect_error(assert_vector(list(1:5, 1:10)))
   expect_error(assert_vector(data.frame(1:5, 2:6)))
 })
 
 #------------------------------------------------
 test_that("assert_matrix working correctly", {
-  expect_true(assert_matrix(matrix(NA,1,1)))
-  expect_true(assert_matrix(matrix(5,3,3)))
+  expect_true(assert_matrix(matrix(NA, 1, 1)))
+  expect_true(assert_matrix(matrix(5, 3, 3)))
 
   expect_error(assert_matrix(NULL))
   expect_error(assert_matrix(5))
@@ -250,88 +248,88 @@ test_that("assert_custom_class working correctly", {
 
 #------------------------------------------------
 test_that("assert_eq working correctly", {
-  expect_true(assert_eq(5,5))
-  expect_true(assert_eq(1:5,1:5))
-  expect_true(assert_eq("foo","foo"))
+  expect_true(assert_eq(5, 5))
+  expect_true(assert_eq(1:5, 1:5))
+  expect_true(assert_eq("foo", "foo"))
   expect_true(assert_eq(c(a = 5), c(b = 5)))
 
-  expect_error(assert_eq(NULL,5))
-  expect_error(assert_eq(5,NULL))
-  expect_error(assert_eq(NULL,NULL))
-  expect_error(assert_eq(4,5))
-  expect_error(assert_eq(1:4,1:5))
-  expect_error(assert_eq("foo","bar"))
+  expect_error(assert_eq(NULL, 5))
+  expect_error(assert_eq(5, NULL))
+  expect_error(assert_eq(NULL, NULL))
+  expect_error(assert_eq(4, 5))
+  expect_error(assert_eq(1:4, 1:5))
+  expect_error(assert_eq("foo", "bar"))
 })
 
 #------------------------------------------------
 test_that("assert_neq working correctly", {
-  expect_true(assert_neq(4,5))
-  expect_true(assert_neq(2:6,1:5))
-  expect_true(assert_neq("foo","bar"))
+  expect_true(assert_neq(4, 5))
+  expect_true(assert_neq(2:6, 1:5))
+  expect_true(assert_neq("foo", "bar"))
 
-  expect_error(assert_neq(NULL,5))
-  expect_error(assert_neq(5,NULL))
-  expect_error(assert_neq(NULL,NULL))
-  expect_error(assert_neq(5,5))
-  expect_error(assert_neq(1:5,1:5))
-  expect_error(assert_neq("foo","foo"))
+  expect_error(assert_neq(NULL, 5))
+  expect_error(assert_neq(5, NULL))
+  expect_error(assert_neq(NULL, NULL))
+  expect_error(assert_neq(5, 5))
+  expect_error(assert_neq(1:5, 1:5))
+  expect_error(assert_neq("foo", "foo"))
 })
 
 #------------------------------------------------
 test_that("assert_gr working correctly", {
-  expect_true(assert_gr(5,4))
-  expect_true(assert_gr(1:5,0))
-  expect_true(assert_gr(2:6,1:5))
+  expect_true(assert_gr(5, 4))
+  expect_true(assert_gr(1:5, 0))
+  expect_true(assert_gr(2:6, 1:5))
 
-  expect_error(assert_gr(NULL,5))
-  expect_error(assert_gr(5,NULL))
-  expect_error(assert_gr(NULL,NULL))
-  expect_error(assert_gr(3,3))
-  expect_error(assert_gr(3,4))
-  expect_error(assert_gr(1:4,1:5))
+  expect_error(assert_gr(NULL, 5))
+  expect_error(assert_gr(5, NULL))
+  expect_error(assert_gr(NULL, NULL))
+  expect_error(assert_gr(3, 3))
+  expect_error(assert_gr(3, 4))
+  expect_error(assert_gr(1:4, 1:5))
 })
 
 #------------------------------------------------
 test_that("assert_greq working correctly", {
-  expect_true(assert_greq(5,4))
-  expect_true(assert_greq(5,5))
-  expect_true(assert_greq(1:5,0))
-  expect_true(assert_greq(2:6,1:5))
-  expect_true(assert_greq(1:5,1:5))
+  expect_true(assert_greq(5, 4))
+  expect_true(assert_greq(5, 5))
+  expect_true(assert_greq(1:5, 0))
+  expect_true(assert_greq(2:6, 1:5))
+  expect_true(assert_greq(1:5, 1:5))
 
-  expect_error(assert_greq(NULL,5))
-  expect_error(assert_greq(5,NULL))
-  expect_error(assert_greq(NULL,NULL))
-  expect_error(assert_greq(3,4))
-  expect_error(assert_greq(1:4,1:5))
+  expect_error(assert_greq(NULL, 5))
+  expect_error(assert_greq(5, NULL))
+  expect_error(assert_greq(NULL, NULL))
+  expect_error(assert_greq(3, 4))
+  expect_error(assert_greq(1:4, 1:5))
 })
 
 #------------------------------------------------
 test_that("assert_le working correctly", {
-  expect_true(assert_le(4,5))
-  expect_true(assert_le(1:5,9))
-  expect_true(assert_le(2:6,3:7))
+  expect_true(assert_le(4, 5))
+  expect_true(assert_le(1:5, 9))
+  expect_true(assert_le(2:6, 3:7))
 
-  expect_error(assert_le(NULL,5))
-  expect_error(assert_le(5,NULL))
-  expect_error(assert_le(NULL,NULL))
-  expect_error(assert_le(3,3))
-  expect_error(assert_le(4,3))
-  expect_error(assert_le(1:4,1:5))
+  expect_error(assert_le(NULL, 5))
+  expect_error(assert_le(5, NULL))
+  expect_error(assert_le(NULL, NULL))
+  expect_error(assert_le(3, 3))
+  expect_error(assert_le(4, 3))
+  expect_error(assert_le(1:4, 1:5))
 })
 
 #------------------------------------------------
 test_that("assert_leq working correctly", {
-  expect_true(assert_leq(4,5))
-  expect_true(assert_leq(4,4))
-  expect_true(assert_leq(1:5,9))
-  expect_true(assert_leq(2:6,2:6))
+  expect_true(assert_leq(4, 5))
+  expect_true(assert_leq(4, 4))
+  expect_true(assert_leq(1:5, 9))
+  expect_true(assert_leq(2:6, 2:6))
 
-  expect_error(assert_leq(NULL,5))
-  expect_error(assert_leq(5,NULL))
-  expect_error(assert_leq(NULL,NULL))
-  expect_error(assert_leq(4,3))
-  expect_error(assert_leq(2:6,1:5))
+  expect_error(assert_leq(NULL, 5))
+  expect_error(assert_leq(5, NULL))
+  expect_error(assert_leq(NULL, NULL))
+  expect_error(assert_leq(4, 3))
+  expect_error(assert_leq(2:6, 1:5))
 })
 
 #------------------------------------------------
@@ -377,14 +375,14 @@ test_that("assert_not_in working correctly", {
 test_that("assert_length working correctly", {
   expect_true(assert_length(1:3, 3))
   expect_true(assert_length(3, 1))
-  expect_true(assert_length(matrix(NA,3,4), 12))
+  expect_true(assert_length(matrix(NA, 3, 4), 12))
 
   expect_error(assert_length(1:3, NULL))
   expect_error(assert_length(NULL, 1:3))
   expect_error(assert_length(NULL, NULL))
   expect_error(assert_length(3, 2))
   expect_error(assert_length(1:3, 2))
-  expect_error(assert_length(matrix(NA,3,4), 9))
+  expect_error(assert_length(matrix(NA, 3, 4), 9))
 })
 
 #------------------------------------------------
@@ -405,50 +403,50 @@ test_that("assert_same_length_multiple working correctly", {
 
 #------------------------------------------------
 test_that("assert_2d working correctly", {
-  expect_true(assert_2d(matrix(NA,3,3)))
-  expect_true(assert_2d(matrix(NA,0,0)))
-  expect_true(assert_2d(data.frame(1:3,1:3)))
+  expect_true(assert_2d(matrix(NA, 3, 3)))
+  expect_true(assert_2d(matrix(NA, 0, 0)))
+  expect_true(assert_2d(data.frame(1:3, 1:3)))
 
   expect_error(assert_2d(NULL))
   expect_error(assert_2d(5))
-  expect_error(assert_2d(array(NA, dim = c(2,3,4))))
+  expect_error(assert_2d(array(NA, dim = c(2, 3, 4))))
 })
 
 #------------------------------------------------
 test_that("assert_nrow working correctly", {
-  expect_true(assert_nrow(matrix(NA,3,3), 3))
-  expect_true(assert_nrow(data.frame(1:5,1:5), 5))
+  expect_true(assert_nrow(matrix(NA, 3, 3), 3))
+  expect_true(assert_nrow(data.frame(1:5, 1:5), 5))
 
   expect_error(assert_nrow(NULL, 3))
   expect_error(assert_nrow(3, NULL))
   expect_error(assert_nrow(NULL, NULL))
   expect_error(assert_nrow(5, 1))
-  expect_error(assert_nrow(data.frame(1:5,1:5), 4))
+  expect_error(assert_nrow(data.frame(1:5, 1:5), 4))
 })
 
 #------------------------------------------------
 test_that("assert_ncol working correctly", {
-  expect_true(assert_ncol(matrix(NA,3,3), 3))
-  expect_true(assert_ncol(data.frame(1:5,1:5), 2))
+  expect_true(assert_ncol(matrix(NA, 3, 3), 3))
+  expect_true(assert_ncol(data.frame(1:5, 1:5), 2))
 
   expect_error(assert_ncol(NULL, 3))
   expect_error(assert_ncol(3, NULL))
   expect_error(assert_ncol(NULL, NULL))
   expect_error(assert_ncol(5, 1))
-  expect_error(assert_ncol(data.frame(1:5,1:5), 3))
+  expect_error(assert_ncol(data.frame(1:5, 1:5), 3))
 })
 
 #------------------------------------------------
 test_that("assert_dim working correctly", {
-  expect_true(assert_dim(matrix(NA,3,3), c(3,3)))
-  expect_true(assert_dim(data.frame(1:5,1:5), c(5,2)))
+  expect_true(assert_dim(matrix(NA, 3, 3), c(3, 3)))
+  expect_true(assert_dim(data.frame(1:5, 1:5), c(5, 2)))
 
   expect_error(assert_dim(NULL, 3))
   expect_error(assert_dim(3, NULL))
   expect_error(assert_dim(NULL, NULL))
   expect_error(assert_dim(5, 1))
-  expect_error(assert_dim(data.frame(1:5,1:5), c(3,2)))
-  expect_error(assert_dim(data.frame(1:5,1:5), c(5,3)))
+  expect_error(assert_dim(data.frame(1:5, 1:5), c(3, 2)))
+  expect_error(assert_dim(data.frame(1:5, 1:5), c(5, 3)))
 })
 
 #------------------------------------------------
@@ -482,6 +480,6 @@ test_that("assert_noduplicates working correctly", {
   expect_true(assert_noduplicates(c("foo", "bar")))
   expect_true(assert_noduplicates(NULL))
 
-  expect_error(assert_noduplicates(c(1,1,2)))
+  expect_error(assert_noduplicates(c(1, 1, 2)))
   expect_error(assert_noduplicates(c("foo", "bar", "foo")))
 })

--- a/tests/testthat/test_probability.R
+++ b/tests/testthat/test_probability.R
@@ -1,20 +1,11 @@
-context("probabilities")
-
-#------------------------------------------------
 test_that("rdirichlet works", {
-
   set.seed(1)
-  out <- rdirichlet(rep(1,3))
+  out <- rdirichlet(rep(1, 3))
   expect_equal(round(out, 3), c(0.04, 0.49, 0.47))
-
 })
 
-#------------------------------------------------
 test_that("rbetabinomial works", {
-
   set.seed(1)
   out <- rbetabinom(1, 10, 1, 1)
   expect_equal(out, 7)
-
 })
-

--- a/tests/testthat/test_simulations.R
+++ b/tests/testthat/test_simulations.R
@@ -1,8 +1,4 @@
-context("simulation")
-
-#------------------------------------------------
 test_that("sim_biallelic works", {
-
   set.seed(1)
 
   # define number of loci, and distribution of minor allele frequencies
@@ -14,13 +10,9 @@ test_that("sim_biallelic works", {
   sim1 <- sim_biallelic(coi = k, plaf = p, overdispersion = 0.01)
   expect_identical(names(sim1), c("coi", "strain_proportions", "phased", "data", "inputs"))
   expect_equal(round(sim1$strain_proportions, 2), c(0.62, 0.38))
-
 })
 
-
-#------------------------------------------------
 test_that("sim_biallelic relatedness works", {
-
   set.seed(1)
 
   # define number of loci, and distribution of minor allele frequencies
@@ -40,5 +32,4 @@ test_that("sim_biallelic relatedness works", {
   # we would expect in related samples there will be more homozyogous calls
   expect_gt(tbl2[1], tbl1[1])
   expect_gt(tbl2[4], tbl1[4])
-
 })

--- a/tests/testthat/test_theoretical_coi.R
+++ b/tests/testthat/test_theoretical_coi.R
@@ -1,21 +1,17 @@
-context("theoretical coi")
-
-#------------------------------------------------
-test_that("single_theoretical_coi method 1 works", {
-  # define coi and interval
-  coi = 2
-  interval = seq(0, 0.5, 0.25)
+test_that("variant method works", {
+  # Define coi and interval
+  coi <- 2
+  interval <- seq(0, 0.5, 0.25)
 
   curve <- single_theoretical_coi(coi, interval)
   expect_equal(curve, c(0.00, 0.375, 0.5))
 })
 
-#------------------------------------------------
-test_that("single_theoretical_coi method 2 works", {
-  # define coi and interval
-  coi = 4
-  interval = seq(0.01, 0.50, 0.24)
+test_that("frequency method works", {
+  # Define coi and interval
+  coi <- 4
+  interval <- seq(0.01, 0.50, 0.24)
 
-  curve <- single_theoretical_coi(coi, interval, coi_method = "2")
+  curve <- single_theoretical_coi(coi, interval, coi_method = "frequency")
   expect_equal(round(curve, 3), c(0.254, 0.362, 0.494))
 })


### PR DESCRIPTION
This PR systematically renames our derived methods as follows:

`"Method 1"` &rarr; `"Variant Method"`
`"Method 2"` &rarr; `"Frequency Method"`

In our code `coi_method = c("1", "2")` &rarr; `coi_method = c("variant", "frequency")`.