### PR TITLE
Check if the COI is 1 for the Frequency Method

### DIFF
--- a/R/check_freq_method.R
+++ b/R/check_freq_method.R
@@ -11,5 +11,5 @@ check_freq_method <- function(wsmaf, plmaf, seq_error) {
 
   # If the actual number of variant sites is less than the lower bound of the CI
   # return FALSE, otherwise return FALSE
-  if (n_variant < bin_ci[2]) FALSE else TRUE
+  if (n_variant < bin_ci[1, "Lower"]) FALSE else TRUE
 }

--- a/R/check_freq_method.R
+++ b/R/check_freq_method.R
@@ -1,0 +1,15 @@
+check_freq_method <- function(wsmaf, plmaf, seq_error) {
+  # Compute number of variant sites
+  variant <- ifelse(wsmaf <= seq_error | wsmaf >= (1 - seq_error), 0, 1)
+  n_variant <- sum(variant)
+
+  # Compute expected number of variant sites using Hardy-Weinberg
+  hardy_weinberg <- 2 * plmaf * (1 - plmaf)
+  n_loci <- length(plmaf)
+
+  bin_ci <- Hmisc::binconf(sum(hardy_weinberg), n_loci) * n_loci
+
+  # If the actual number of variant sites is less than the lower bound of the CI
+  # return FALSE, otherwise return FALSE
+  if (n_variant < bin_ci[2]) FALSE else TRUE
+}

--- a/R/optimize.R
+++ b/R/optimize.R
@@ -125,9 +125,20 @@ optimize_coi <- function(data,
     cuts <- processed$cuts
   }
 
-  # Special case where there are no heterozygous sites
-  if (nrow(processed_data) == 0) {
-    return(coi <- 1)
+  # Special cases for the Frequency Method where COI = 1
+  if (coi_method == "frequency") {
+    check <- switch(data_type,
+      "sim" = check_freq_method(data$data$wsmaf, data$data$plmaf, seq_error),
+      "real" = check_freq_method(data$wsmaf, data$plmaf, seq_error)
+    )
+
+    # If the check returns FALSE, it means that the COI is likely 1
+    if (!check) {
+      return(structure(
+        1,
+        notes = "Too few variant loci suggesting that the COI is 1 based on the Variant Method."
+      ))
+    }
   }
 
   # Compute COI


### PR DESCRIPTION
The Frequency Method is not defined for a COI less than 2. This PR improves the technique we use to determine if the COI can be computed for the Frequency Method. To do so, we compare the expected number of variant sites to the actual number of variant sites. If the actual number of variant sites is less than the lower bound of the confidence interval, we return a COI of 1 and add a note explaining to the user why we estimated the COI as 1.
