### PR TITLE
Weigh loci by read coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 
 ## New features
 
+- Within sample minor allele frequencies are now weighed by read coverage. If no
+  coverage is supplied, the coverage is assumed to be uniform across all loci
+  (#16.)
 - New `theme_coiaf()` creates a custom theme for this package.
 
 ## Bug Fixes

--- a/R/compute_coi.R
+++ b/R/compute_coi.R
@@ -96,9 +96,16 @@ compute_coi <- function(data,
     bin_size <- processed$bin_size
     cuts <- processed$cuts
   } else if (data_type == "real") {
+    # If no coverage is provided, we assume that the coverage is uniform across
+    # all loci
+    if (!"coverage" %in% colnames(data)) {
+      data$coverage <- rep(100, length(data$wsmaf))
+    }
+
     processed <- process_real(
       data$wsmaf,
       data$plmaf,
+      data$coverage,
       seq_error,
       bin_size,
       coi_method

--- a/R/optimize.R
+++ b/R/optimize.R
@@ -121,7 +121,20 @@ optimize_coi <- function(data,
     bin_size <- processed$bin_size
     cuts <- processed$cuts
   } else if (data_type == "real") {
-    processed <- process_real(data$wsmaf, data$plmaf, seq_error, bin_size, coi_method)
+    # If no coverage is provided, we assume that the coverage is uniform across
+    # all loci
+    if (!"coverage" %in% colnames(data)) {
+      data$coverage <- rep(100, length(data$wsmaf))
+    }
+
+    processed <- process_real(
+      data$wsmaf,
+      data$plmaf,
+      data$coverage,
+      seq_error,
+      bin_size,
+      coi_method
+    )
     processed_data <- processed$data
     seq_error <- processed$seq_error
     bin_size <- processed$bin_size

--- a/R/process.R
+++ b/R/process.R
@@ -24,6 +24,7 @@
 
 process <- function(wsmaf,
                     plmaf,
+                    coverage,
                     seq_error = NULL,
                     bin_size = 20,
                     coi_method = "variant") {
@@ -64,14 +65,16 @@ process <- function(wsmaf,
     # accounting for sequence error
     df <- data.frame(
       plmaf_cut = suppressWarnings(Hmisc::cut2(plmaf, m = bin_size)),
-      variant = ifelse(wsmaf <= seq_error | wsmaf >= (1 - seq_error), 0, 1)
+      variant = ifelse(wsmaf <= seq_error | wsmaf >= (1 - seq_error), 0, 1),
+      coverage = coverage
     )
   } else if (coi_method == "frequency") {
     # Subset to heterozygous sites
-    data <- data.frame(wsmaf = wsmaf, plmaf = plmaf) %>%
+    data <- data.frame(wsmaf = wsmaf, plmaf = plmaf, coverage = coverage) %>%
       dplyr::filter(wsmaf > seq_error & wsmaf < (1 - seq_error))
     wsmaf <- data$wsmaf
     plmaf <- data$plmaf
+    coverage <- data$coverage
 
     # If remove all data, need to return a pseudo result to not induce errors.
     # Additionally, in order to define a cut, need at least 2 data points
@@ -93,7 +96,8 @@ process <- function(wsmaf,
     # Isolate PLMAF, and keep WSMAF as is
     df <- data.frame(
       plmaf_cut = suppressWarnings(Hmisc::cut2(plmaf, m = bin_size)),
-      variant = wsmaf
+      variant = wsmaf,
+      coverage = coverage
     )
   }
 
@@ -126,7 +130,7 @@ process <- function(wsmaf,
   df_grouped <- df %>%
     dplyr::group_by(.data$plmaf_cut, .drop = FALSE) %>%
     dplyr::summarise(
-      m_variant   = mean(.data$variant),
+      m_variant   = stats::weighted.mean(.data$variant, .data$coverage),
       bucket_size = dplyr::n()
     ) %>%
     stats::na.omit()
@@ -194,6 +198,7 @@ process_sim <- function(sim,
   process(
     wsmaf = sim$data$wsmaf,
     plmaf = sim$data$plmaf,
+    coverage = sim$data$coverage,
     seq_error = seq_error,
     bin_size = bin_size,
     coi_method = coi_method
@@ -228,7 +233,9 @@ process_sim <- function(sim,
 #' @seealso [process_sim()] to process simulated data.
 #' @export
 
-process_real <- function(wsmaf, plmaf,
+process_real <- function(wsmaf,
+                         plmaf,
+                         coverage,
                          seq_error = NULL,
                          bin_size = 20,
                          coi_method = "variant") {
@@ -240,7 +247,7 @@ process_real <- function(wsmaf, plmaf,
   if (!is.null(seq_error)) assert_single_bounded(seq_error)
   assert_single_pos_int(bin_size)
 
-  input <- tibble::tibble(wsmaf = wsmaf, plmaf = plmaf) %>%
+  input <- tibble::tibble(wsmaf = wsmaf, plmaf = plmaf, coverage = coverage) %>%
     tidyr::drop_na()
 
   # In some cases we are fed in the major allele so we ensure we only examine
@@ -258,6 +265,7 @@ process_real <- function(wsmaf, plmaf,
   process(
     wsmaf = minor$wsmaf,
     plmaf = minor$plmaf,
+    coverage = minor$coverage,
     seq_error = seq_error,
     bin_size = bin_size,
     coi_method = coi_method

--- a/R/process.R
+++ b/R/process.R
@@ -216,6 +216,7 @@ process_sim <- function(sim,
 #'
 #' @param wsmaf The within-sample allele frequency.
 #' @param plmaf The population-level allele frequency.
+#' @param coverage The read coverage at each locus.
 #' @inheritParams process_sim
 #'
 #' @return A list of the following:

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -4,12 +4,21 @@
 \alias{process}
 \title{Process data}
 \usage{
-process(wsmaf, plmaf, seq_error = NULL, bin_size = 20, coi_method = "variant")
+process(
+  wsmaf,
+  plmaf,
+  coverage,
+  seq_error = NULL,
+  bin_size = 20,
+  coi_method = "variant"
+)
 }
 \arguments{
 \item{wsmaf}{The within-sample allele frequency.}
 
 \item{plmaf}{The population-level allele frequency.}
+
+\item{coverage}{The read coverage at each locus.}
 
 \item{seq_error}{The level of sequencing error that is assumed. If no value
 is inputted, then we infer the level of sequence error.}

--- a/man/process_real.Rd
+++ b/man/process_real.Rd
@@ -7,6 +7,7 @@
 process_real(
   wsmaf,
   plmaf,
+  coverage,
   seq_error = NULL,
   bin_size = 20,
   coi_method = "variant"
@@ -16,6 +17,8 @@ process_real(
 \item{wsmaf}{The within-sample allele frequency.}
 
 \item{plmaf}{The population-level allele frequency.}
+
+\item{coverage}{The read coverage at each locus.}
 
 \item{seq_error}{The level of sequencing error that is assumed. If no value
 is inputted, then we infer the level of sequence error.}


### PR DESCRIPTION
In many cases, read coverage will differ at each locus. The read coverage can be an indication of the sequencing quality at each locus. This PR adds the ability for our algorithms to weigh loci by their coverage. To keep our code backward compatible, if the real data input has no coverage we assume that the coverage for each locus is uniform.
