### PR TITLE
Bootstrap errors when there is no uncertainty in results

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -139,10 +139,10 @@ bootstrap_ci.sim <- function(data,
     bin_size = 20
   )
 
-  tryCatch(
-    tidy_boot_out <- broom::tidy(boot_out, conf.int = TRUE),
+  tidy_boot_out <- tryCatch(
+    broom::tidy(boot_out, conf.int = TRUE),
     error = function(e) {
-      tidy_boot_out <- broom::tidy(boot_out, conf.int = FALSE) %>%
+      broom::tidy(boot_out, conf.int = FALSE) %>%
         tibble::add_column(conf.low = NaN, conf.high = NaN)
     }
   )

--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -49,8 +49,8 @@ test_that("length of strain proportions is the COI", {
 })
 
 test_that("strain proporitons sum to 1", {
-  expect_true(sum(sim_biallelic(5)$strain_proportions$proportion) == 1)
-  expect_true(sum(sim_biallelic(15)$strain_proportions$proportion) == 1)
+  expect_equal(sum(sim_biallelic(5)$strain_proportions$proportion), 1)
+  expect_equal(sum(sim_biallelic(15)$strain_proportions$proportion), 1)
 })
 
 test_that("phased haplotypes dimensions are correct", {


### PR DESCRIPTION
This PR addresses an issue where the bootstrapping code errors when there is no uncertainty in the results.